### PR TITLE
fix action.read()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,9 @@ jobs:
               --type instrumentation
               --app test-app/build/outputs/apk/debug/test-app-debug.apk
               --test test-app/build/outputs/apk/androidTest/debug/test-app-debug-androidTest.apk
+              --device model=Nexus5,version=19,locale=en_US,orientation=portrait
               --device model=Nexus5,version=22,locale=en_US,orientation=portrait
+              --device model=Nexus5X,version=24,locale=en_US,orientation=portrait
               --directories-to-pull=/sdcard/tmp
               --use-orchestrator
               --no-record-video

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Project" />
   </state>
 </component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ buildscript {
 }
 
 group = "com.avito.ui-testing"
-version = "0.2.1"
+version = "0.2.2"
 
 val minSdk: String by project
 val targetSdk: String by project

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 minSdk=18
 targetSdk=27
-kotlinVersion=1.2.41
+kotlinVersion=1.2.60
 espressoVersion=3.0.1
 supportVersion=27.0.2
 junitVersion=4.12

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip

--- a/test-app/src/androidTest/java/com/avito/android/ui/test/ButtonsOverRecyclerTest.kt
+++ b/test-app/src/androidTest/java/com/avito/android/ui/test/ButtonsOverRecyclerTest.kt
@@ -17,8 +17,8 @@ class ButtonsOverRecyclerTest {
         with(Screen.buttonsOverRecycler.list) {
             actions.swipe(SwipeDirections.BOTTOM_TO_TOP)
             checks.firstVisiblePosition(greaterThan(0))
-            // on some devices swipe to top may end on half way, so do it twice for certainty
-            repeat(2) { actions.swipe(SwipeDirections.TOP_TO_BOTTOM) }
+            // on some devices swipe to top may end on half way
+            repeat(3) { actions.swipe(SwipeDirections.TOP_TO_BOTTOM) }
             checks.firstVisiblePosition(equalTo(0))
         }
     }

--- a/test-app/src/androidTest/java/com/avito/android/ui/test/EditTextScreen.kt
+++ b/test-app/src/androidTest/java/com/avito/android/ui/test/EditTextScreen.kt
@@ -6,5 +6,5 @@ import com.avito.android.ui.R
 
 class EditTextScreen {
 
-    val editText = TextField(ViewMatchers.withId(R.id.text))
+    val editText = TextField(ViewMatchers.withId(R.id.edit_text))
 }

--- a/test-app/src/androidTest/java/com/avito/android/ui/test/EditTextTest.kt
+++ b/test-app/src/androidTest/java/com/avito/android/ui/test/EditTextTest.kt
@@ -1,7 +1,9 @@
 package com.avito.android.ui.test
 
+import android.widget.EditText
 import com.avito.android.test.Device
 import com.avito.android.ui.EditTextActivity
+import com.avito.android.ui.R
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -17,5 +19,17 @@ class EditTextTest {
         launchActivity(null)
 
         Device.keyboard.checks.isDisplayed(activity)
+    }
+
+    @Test
+    fun writesLongText() = with(rule) {
+        launchActivity(null)
+
+        rule.runOnUiThread {
+            activity.findViewById<EditText>(R.id.edit_text).setText("text")
+        }
+
+        Screen.editTextScreen.editText.write("1000000000000000000000000")
+        Screen.editTextScreen.editText.checks.displayedWithText("1000000000000000000000000")
     }
 }

--- a/test-app/src/androidTest/java/com/avito/android/ui/test/ReadTextTest.kt
+++ b/test-app/src/androidTest/java/com/avito/android/ui/test/ReadTextTest.kt
@@ -1,0 +1,57 @@
+package com.avito.android.ui.test
+
+import android.widget.EditText
+import com.avito.android.ui.EditTextActivity
+import com.avito.android.ui.R
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+
+class ReadTextTest {
+
+    @get:Rule
+    val rule = screenRule<EditTextActivity>()
+
+    @get:Rule
+    val exception: ExpectedException = ExpectedException.none()
+
+    @Test
+    fun readNonBlankText_allowBlankIsFalse() = with(rule) {
+        launchActivity(null)
+
+        rule.runOnUiThread {
+            activity.findViewById<EditText>(R.id.edit_text).setText("my_custom_text")
+        }
+
+        val captured = Screen.editTextScreen.editText.read(allowBlank = false)
+        Assert.assertEquals("my_custom_text", captured)
+    }
+
+    @Test
+    fun readBlankText_allowBlankIsFalse() = with(rule) {
+        launchActivity(null)
+
+        rule.runOnUiThread {
+            activity.findViewById<EditText>(R.id.edit_text).setText("")
+        }
+
+        exception.expectMessage("read() waited, but view.text still has empty string value; use read(allowBlank=true) if you really need it")
+        Screen.editTextScreen.editText.read(allowBlank = false)
+        Unit
+    }
+
+    @Test
+    fun readBlankText_allowBlankIsTrue() = with(rule) {
+        launchActivity(null)
+
+        rule.runOnUiThread {
+            activity.findViewById<EditText>(R.id.edit_text).setText("")
+        }
+
+        val captured = Screen.editTextScreen.editText.read(allowBlank = true)
+        Assert.assertEquals("", captured)
+    }
+
+    //todo recycler view tests
+}

--- a/test-app/src/androidTest/java/com/avito/android/ui/test/Screen.kt
+++ b/test-app/src/androidTest/java/com/avito/android/ui/test/Screen.kt
@@ -31,4 +31,7 @@ object Screen {
 
     val startForResultScreen: StartForResultScreen
         get() = StartForResultScreen()
+
+    val editTextScreen: EditTextScreen
+        get() = EditTextScreen()
 }

--- a/ui-testing-core/src/main/java/com/avito/android/test/action/Actions.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/action/Actions.kt
@@ -20,5 +20,5 @@ interface Actions {
         precision: PrecisionDescriber = Press.FINGER
     )
 
-    fun read(): String
+    fun read(allowBlank: Boolean = false): String
 }

--- a/ui-testing-core/src/main/java/com/avito/android/test/action/ActionsImpl.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/action/ActionsImpl.kt
@@ -34,8 +34,8 @@ class ActionsImpl(private val driver: ActionsDriver) : Actions {
         Thread.sleep(1000)
     }
 
-    override fun read(): String =
-        TextViewReadAction()
+    override fun read(allowBlank: Boolean): String =
+        TextViewReadAction(allowBlank)
             .also { driver.perform(it) }
             .result
 }

--- a/ui-testing-core/src/main/java/com/avito/android/test/action/InteractionContextMatcherActions.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/action/InteractionContextMatcherActions.kt
@@ -63,8 +63,8 @@ class InteractionContextMatcherActions(
         Thread.sleep(1000)
     }
 
-    override fun read(): String =
-        TextViewReadAction()
+    override fun read(allowBlank: Boolean): String =
+        TextViewReadAction(allowBlank)
             .also {
                 interactionContext.perform(
                     RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(

--- a/ui-testing-core/src/main/java/com/avito/android/test/action/InteractionContextPositionActions.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/action/InteractionContextPositionActions.kt
@@ -60,8 +60,8 @@ class InteractionContextPositionActions(
         Thread.sleep(1000)
     }
 
-    override fun read(): String =
-        TextViewReadAction()
+    override fun read(allowBlank: Boolean): String =
+        TextViewReadAction(allowBlank)
             .also {
                 interactionContext.perform(
                     RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(

--- a/ui-testing-core/src/main/java/com/avito/android/test/action/OnDescendantMatcherListItemActions.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/action/OnDescendantMatcherListItemActions.kt
@@ -69,8 +69,8 @@ class OnDescendantMatcherListItemActions(
         Thread.sleep(1000)
     }
 
-    override fun read(): String =
-        TextViewReadAction()
+    override fun read(allowBlank: Boolean): String =
+        TextViewReadAction(allowBlank)
             .also {
                 interaction.waitToPerform(
                     RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(

--- a/ui-testing-core/src/main/java/com/avito/android/test/action/OnDescendantPositionListItemActions.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/action/OnDescendantPositionListItemActions.kt
@@ -66,8 +66,8 @@ class OnDescendantPositionListItemActions(
         Thread.sleep(1000)
     }
 
-    override fun read(): String =
-        TextViewReadAction()
+    override fun read(allowBlank: Boolean): String =
+        TextViewReadAction(allowBlank)
             .also {
                 interaction.waitToPerform(
                     RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(

--- a/ui-testing-core/src/main/java/com/avito/android/test/action/WebElementActions.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/action/WebElementActions.kt
@@ -27,7 +27,8 @@ class WebElementActions(private val interaction: Web.WebInteraction<Void>) : Act
         throw UnsupportedOperationException("Swipe is not supported on the Web View")
     }
 
-    override fun read(): String {
+    //todo is there an async problem?
+    override fun read(allowBlank: Boolean): String {
         return interaction.perform(DriverAtoms.getText()).get()
     }
 

--- a/ui-testing-core/src/main/java/com/avito/android/test/espresso/EspressoActions.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/espresso/EspressoActions.kt
@@ -1,12 +1,7 @@
 package com.avito.android.test.espresso
 
 import android.support.test.espresso.ViewAction
-import android.support.test.espresso.action.GeneralSwipeAction
-import android.support.test.espresso.action.PrecisionDescriber
-import android.support.test.espresso.action.Press
-import android.support.test.espresso.action.Swipe
-import android.support.test.espresso.action.SwipeDirection
-import android.support.test.espresso.action.Swiper
+import android.support.test.espresso.action.*
 import android.support.test.espresso.action.ViewActions.actionWithAssertions
 import com.avito.android.test.espresso.action.SafeTypeTextAction
 import com.avito.android.test.espresso.action.ScrollToIfPossibleAction

--- a/ui-testing-core/src/main/java/com/avito/android/test/espresso/action/TextViewReadAction.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/espresso/action/TextViewReadAction.kt
@@ -5,9 +5,11 @@ import android.support.test.espresso.ViewAction
 import android.support.test.espresso.matcher.ViewMatchers
 import android.view.View
 import android.widget.TextView
+import com.avito.android.test.waitFor
+import junit.framework.Assert
 import org.hamcrest.Matcher
 
-class TextViewReadAction : ViewAction {
+class TextViewReadAction(private val allowBlank: Boolean) : ViewAction {
 
     lateinit var result: String
         private set
@@ -18,6 +20,18 @@ class TextViewReadAction : ViewAction {
     override fun getDescription(): String = "getting text from a TextView"
 
     override fun perform(uiController: UiController, view: View) {
-        result = (view as TextView).text.toString()
+        if (allowBlank) {
+            result = view.readText()
+        } else {
+            waitFor {
+                result = view.readText()
+                Assert.assertTrue(
+                    "read() waited, but view.text still has empty string value; use read(allowBlank=true) if you really need it",
+                    result.isNotBlank()
+                )
+            }
+        }
     }
+
+    private fun View.readText(): String = (this as TextView).text.toString()
 }

--- a/ui-testing-core/src/main/java/com/avito/android/test/page_object/TextField.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/page_object/TextField.kt
@@ -35,9 +35,9 @@ class TextFieldActionImpl(private val interactionContext: InteractionContext) :
     Actions by ActionsImpl(interactionContext) {
 
     override fun write(text: String) {
-        clear()
         interactionContext.perform(
             actionWithAssertions(ScrollToIfPossibleAction()),
+            clearText(),
             actionWithAssertions(SafeTypeTextAction(text, true))
         )
         Espresso.closeSoftKeyboard()


### PR DESCRIPTION
problem was in async setText calls, we read empty value sometimes
now you must specify allowBlank in read(), default=false

also bump kotlin and add 19 and 24 devices for test runs