### PR TITLE
add toolbar checks with string matcher

### DIFF
--- a/test-app/src/androidTest/java/com/avito/android/ui/test/AppBarScreen.kt
+++ b/test-app/src/androidTest/java/com/avito/android/ui/test/AppBarScreen.kt
@@ -2,12 +2,15 @@ package com.avito.android.ui.test
 
 import android.support.test.espresso.matcher.ViewMatchers
 import com.avito.android.test.page_object.AppBarElement
+import com.avito.android.test.page_object.ToolbarElement
 import com.avito.android.test.page_object.ViewElement
 import com.avito.android.ui.R
 
 class AppBarScreen {
 
     val appBar = AppBarElement(ViewMatchers.withId(R.id.appbar))
+
+    val toolbar = ToolbarElement(ViewMatchers.withId(R.id.toolbar))
 
     val testView = ViewElement(ViewMatchers.withId(R.id.view_in_collapsing_toolbar))
 }

--- a/test-app/src/androidTest/java/com/avito/android/ui/test/AppBarTest.kt
+++ b/test-app/src/androidTest/java/com/avito/android/ui/test/AppBarTest.kt
@@ -1,6 +1,8 @@
 package com.avito.android.ui.test
 
 import com.avito.android.ui.AppBarActivity
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.startsWith
 import org.junit.Rule
 import org.junit.Test
 
@@ -16,6 +18,8 @@ class AppBarTest {
         rule.activity.setExpanded(true)
 
         Screen.appBarScreen.appBar.actions.collapse()
+        Screen.appBarScreen.toolbar.checks.withTitle(startsWith("Tit"))
+        Screen.appBarScreen.toolbar.checks.withSubtitle(`is`("Subtitle"))
         Screen.appBarScreen.testView.checks.isNotCompletelyDisplayed()
     }
 

--- a/test-app/src/main/java/com/avito/android/ui/AppBarActivity.kt
+++ b/test-app/src/main/java/com/avito/android/ui/AppBarActivity.kt
@@ -14,6 +14,8 @@ class AppBarActivity : AppCompatActivity() {
         setContentView(R.layout.activity_app_bar)
         appBarLayout = findViewById(R.id.appbar)
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        toolbar.title = "Title"
+        toolbar.subtitle = "Subtitle"
         setSupportActionBar(toolbar)
     }
 

--- a/ui-testing-core/src/main/java/com/avito/android/test/matcher/ToolbarSubtitleMatcher.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/matcher/ToolbarSubtitleMatcher.kt
@@ -7,10 +7,10 @@ import org.hamcrest.Description
 import org.hamcrest.Matcher
 
 internal class ToolbarSubtitleMatcher(
-    private val textMatcher: Matcher<CharSequence>
+    private val textMatcher: Matcher<out CharSequence>
 ) : BoundedMatcher<View, Toolbar>(Toolbar::class.java) {
 
-    private var actualText: String? = null
+    private var actualText: CharSequence? = null
 
     override fun describeTo(description: Description) {
         description.appendText("with toolbar subtitle: ")
@@ -21,7 +21,7 @@ internal class ToolbarSubtitleMatcher(
     }
 
     override fun matchesSafely(toolbar: Toolbar): Boolean {
-        actualText = toolbar.subtitle.toString()
+        actualText = toolbar.subtitle
         return textMatcher.matches(actualText)
     }
 }

--- a/ui-testing-core/src/main/java/com/avito/android/test/matcher/ToolbarTitleMatcher.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/matcher/ToolbarTitleMatcher.kt
@@ -9,11 +9,10 @@ import org.hamcrest.Matcher
 /**
  * from http://blog.sqisland.com/2015/05/espresso-match-toolbar-title.html
  */
-internal class ToolbarTitleMatcher(
-    private val textMatcher: Matcher<CharSequence>
-) : BoundedMatcher<View, Toolbar>(Toolbar::class.java) {
+internal class ToolbarTitleMatcher(private val textMatcher: Matcher<out CharSequence>) :
+        BoundedMatcher<View, Toolbar>(Toolbar::class.java) {
 
-    private var actualText: String? = null
+    private var actualText: CharSequence? = null
 
     override fun describeTo(description: Description) {
         description.appendText("with toolbar title: ")
@@ -24,7 +23,7 @@ internal class ToolbarTitleMatcher(
     }
 
     override fun matchesSafely(toolbar: Toolbar): Boolean {
-        actualText = toolbar.title?.toString()
+        actualText = toolbar.title
         return textMatcher.matches(actualText)
     }
 }

--- a/ui-testing-core/src/main/java/com/avito/android/test/page_object/ToolbarElement.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/page_object/ToolbarElement.kt
@@ -208,9 +208,13 @@ interface ToolbarElementChecks : Checks {
 
     fun withTitle(text: String)
 
+    fun withTitle(matcher: Matcher<String>)
+
     fun withTitle(@StringRes resId: Int)
 
     fun withSubtitle(text: String)
+
+    fun withSubtitle(matcher: Matcher<String>)
 
     fun withSubtitle(@StringRes resId: Int)
 }
@@ -222,8 +226,16 @@ class ToolbarElementChecksImpl(private val driver: ChecksDriver) : ToolbarElemen
         driver.check(ViewAssertions.matches(ToolbarTitleMatcher(`is`(text))))
     }
 
+    override fun withTitle(matcher: Matcher<String>) {
+        driver.check(ViewAssertions.matches(ToolbarTitleMatcher(matcher)))
+    }
+
     override fun withTitle(@StringRes resId: Int) {
         driver.check(ViewAssertions.matches(ToolbarTitleResMatcher(resId)))
+    }
+
+    override fun withSubtitle(matcher: Matcher<String>) {
+        driver.check(ViewAssertions.matches(ToolbarSubtitleMatcher(matcher)))
     }
 
     override fun withSubtitle(text: String) {


### PR DESCRIPTION
Added availability to work with already existed string matchers when it comes to checking title and subtitle in toolbar