### PR TITLE
ScrollToElementAction, ViewActionOnItemAtPosition

### DIFF
--- a/test-app/src/androidTest/java/com/avito/android/ui/test/RecyclerWithSingleLongItemScreen.kt
+++ b/test-app/src/androidTest/java/com/avito/android/ui/test/RecyclerWithSingleLongItemScreen.kt
@@ -1,0 +1,10 @@
+package com.avito.android.ui.test
+
+import android.support.test.espresso.matcher.ViewMatchers
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import com.avito.android.test.page_object.ListElement
+import com.avito.android.ui.R
+
+class RecyclerWithSingleLongItemScreen : ListElement(ViewMatchers.withId(R.id.recycler)) {
+    val list = ListElement(withId(R.id.recycler))
+}

--- a/test-app/src/androidTest/java/com/avito/android/ui/test/RecyclerWithSingleLongItemTest.kt
+++ b/test-app/src/androidTest/java/com/avito/android/ui/test/RecyclerWithSingleLongItemTest.kt
@@ -1,0 +1,118 @@
+package com.avito.android.ui.test
+
+import android.support.test.espresso.action.ViewActions
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import com.avito.android.ui.RecyclerWithLongItemsActivity
+import org.junit.Rule
+import org.junit.Test
+import com.avito.android.ui.R
+import org.hamcrest.Matchers.allOf
+
+class RecyclerWithSingleLongItemTest {
+
+    @get:Rule
+    val rule = screenRule<RecyclerWithLongItemsActivity>()
+
+    @Test
+    fun single_reversed_top() {
+        test(
+            DataSet(
+                reversed = true,
+                targetViews = listOf(R.id.target_view_top)
+            )
+        )
+    }
+
+    @Test
+    fun single_top() {
+        test(
+            DataSet(
+                reversed = false,
+                targetViews = listOf(R.id.target_view_top)
+            )
+        )
+    }
+
+    @Test
+    fun single_reversed_bottom() {
+        test(
+            DataSet(
+                reversed = true,
+                targetViews = listOf(R.id.target_view_bottom)
+            )
+        )
+    }
+
+    @Test
+    fun single_bottom() {
+        test(
+            DataSet(
+                reversed = false,
+                targetViews = listOf(R.id.target_view_bottom)
+            )
+        )
+    }
+
+    @Test
+    fun multiple() {
+        test(
+            DataSet(
+                reversed = false,
+                targetViews = listOf(
+                    R.id.target_view_top,
+                    R.id.target_view_center,
+                    R.id.target_view_bottom
+                )
+            )
+        )
+    }
+
+    @Test
+    fun multiple_reversed() {
+        test(
+            DataSet(
+                reversed = true,
+                targetViews = listOf(
+                    R.id.target_view_top,
+                    R.id.target_view_center,
+                    R.id.target_view_bottom
+                )
+            )
+        )
+    }
+
+    @Test
+    fun multiple_kek() {
+        test(
+            DataSet(
+                reversed = false,
+                targetViews = listOf(
+                    R.id.target_view_center,
+                    R.id.target_view_bottom,
+                    R.id.target_view_top
+                )
+            )
+        )
+    }
+
+    private fun test(dataSet: DataSet) {
+        rule.launchActivity(RecyclerWithLongItemsActivity.intent(dataSet.reversed))
+
+        with(Screen.recyclerWithSingleLongItemScreen.list) {
+            for (targetView in dataSet.targetViews.shuffled()) {
+                actions.actionOnChild(
+                    position = 0,
+                    targetChildViewId = targetView,
+                    childMatcher = allOf(withId(targetView), isDisplayed()),
+                    action = ViewActions.click()
+                )
+            }
+        }
+    }
+
+    data class DataSet(
+        val reversed: Boolean,
+        val targetViews: List<Int>
+    )
+}

--- a/test-app/src/androidTest/java/com/avito/android/ui/test/Screen.kt
+++ b/test-app/src/androidTest/java/com/avito/android/ui/test/Screen.kt
@@ -40,4 +40,7 @@ object Screen {
 
     val backgroundDrawableScreen: BackgroundDrawableScreen
         get() = BackgroundDrawableScreen()
+
+    val recyclerWithSingleLongItemScreen: RecyclerWithSingleLongItemScreen
+        get() = RecyclerWithSingleLongItemScreen()
 }

--- a/test-app/src/main/AndroidManifest.xml
+++ b/test-app/src/main/AndroidManifest.xml
@@ -23,5 +23,6 @@
             android:name=".EditTextActivity"
             android:windowSoftInputMode="stateVisible|adjustResize" />
         <activity android:name=".StartForResultActivity" />
+        <activity android:name=".RecyclerWithLongItemsActivity" />
     </application>
 </manifest>

--- a/test-app/src/main/java/com/avito/android/ui/RecyclerWithLongItemsActivity.kt
+++ b/test-app/src/main/java/com/avito/android/ui/RecyclerWithLongItemsActivity.kt
@@ -1,0 +1,89 @@
+package com.avito.android.ui
+
+import android.content.Intent
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import java.lang.IllegalStateException
+
+class RecyclerWithLongItemsActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_recycler)
+
+        findViewById<RecyclerView>(R.id.recycler).apply {
+            layoutManager = LinearLayoutManager(
+                this@RecyclerWithLongItemsActivity,
+                LinearLayoutManager.VERTICAL,
+                intent.getBooleanExtra(EXTRA_REVERSE_LAYOUT, false)
+            )
+            adapter = Adapter()
+        }
+    }
+
+    companion object {
+        private const val EXTRA_REVERSE_LAYOUT = "EXTRA_REVERSE_LAYOUT"
+
+        fun intent(
+            reverseLayout: Boolean
+        ): (Intent) -> Intent = {
+            it.putExtra(EXTRA_REVERSE_LAYOUT, reverseLayout)
+        }
+    }
+
+    private class Adapter :
+        RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+        override fun onBindViewHolder(viewHolder: RecyclerView.ViewHolder?, position: Int) {
+            viewHolder?.let { holder ->
+                val longItemHolder = holder as LongItemHolder
+                longItemHolder.targetViewTop.setAction()
+                longItemHolder.targetViewCenter.setAction()
+                longItemHolder.targetViewBottom.setAction()
+            }
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+            val view = LayoutInflater.from(parent.context)
+                .inflate(R.layout.long_item, parent, false)
+
+            return LongItemHolder(view)
+        }
+
+        override fun getItemCount() = 15
+
+        override fun getItemViewType(position: Int): Int = 0
+
+        private fun View.setAction() {
+            val resources = context.resources
+            val green = resources.getColor(R.color.green)
+            val red = resources.getColor(R.color.red)
+
+            setOnClickListener { clicked ->
+                if ((clicked.background as ColorDrawable).color == green) {
+                    clicked.setBackgroundColor(red)
+                } else {
+                    clicked.setBackgroundColor(green)
+                }
+            }
+        }
+    }
+
+    private class LongItemHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+
+        val targetViewTop = itemView.findViewById<View>(R.id.target_view_top)
+            ?: throw IllegalStateException("R.id.target_view_top not found")
+
+        val targetViewCenter = itemView.findViewById<View>(R.id.target_view_center)
+            ?: throw IllegalStateException("R.id.target_view_top not found")
+
+        val targetViewBottom = itemView.findViewById<View>(R.id.target_view_bottom)
+            ?: throw IllegalStateException("R.id.target_view_top not found")
+    }
+}

--- a/test-app/src/main/res/layout/long_item.xml
+++ b/test-app/src/main/res/layout/long_item.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="3000dp">
+
+    <TextView
+        android:id="@+id/target_view_top"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_gravity="top"
+        android:background="@color/red"
+        android:gravity="center"
+        android:text="top"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/target_view_center"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_gravity="center"
+        android:background="@color/red"
+        android:gravity="center"
+        android:text="center"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/target_view_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_gravity="bottom"
+        android:background="@color/red"
+        android:gravity="center"
+        android:text="bottom"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+</FrameLayout>

--- a/test-app/src/main/res/values/color.xml
+++ b/test-app/src/main/res/values/color.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="red">#FF0000</color>
+    <color name="green">#00FF00</color>
 </resources>

--- a/ui-testing-core/src/main/java/com/avito/android/test/page_object/ListElement.kt
+++ b/ui-testing-core/src/main/java/com/avito/android/test/page_object/ListElement.kt
@@ -1,5 +1,6 @@
 package com.avito.android.test.page_object
 
+import android.support.test.espresso.ViewAction
 import android.support.test.espresso.action.CoordinatesProvider
 import android.support.test.espresso.action.GeneralLocation.BOTTOM_CENTER
 import android.support.test.espresso.action.GeneralLocation.CENTER
@@ -39,8 +40,11 @@ import com.avito.android.test.espresso.action.RecyclerViewHorizontalOffsetAction
 import com.avito.android.test.espresso.action.RecyclerViewItemsCountAction
 import com.avito.android.test.espresso.action.RecyclerViewVerticalOffsetAction
 import com.avito.android.test.espresso.action.ViewGetTranslationYAction
+import com.avito.android.test.espresso.action.ScrollToElementAction
+import com.avito.android.test.espresso.action.ViewActionOnItemAtPosition
 import com.avito.android.test.matcher.RecyclerViewMatcher
 import com.avito.android.test.matcher.ViewGroupMatcher
+import com.forkingcode.espresso.contrib.DescendantViewActions
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.equalTo
@@ -178,6 +182,26 @@ open class ListElement(interactionContext: InteractionContext) :
                     holder,
                     ViewActions.click()
                 ).atPosition(position)
+            )
+        }
+
+        fun scrollToChild(position: Int = 0, targetChildViewId: Int) {
+            driver.perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(position))
+            driver.perform(ScrollToElementAction(position, targetChildViewId))
+        }
+
+        fun actionOnChild(
+            position: Int = 0,
+            targetChildViewId: Int,
+            childMatcher: Matcher<View>,
+            action: ViewAction
+        ) {
+            scrollToChild(position, targetChildViewId)
+            driver.perform(
+                ViewActionOnItemAtPosition<RecyclerView.ViewHolder>(
+                    position,
+                    DescendantViewActions.performDescendantAction(childMatcher, action)
+                )
             )
         }
 


### PR DESCRIPTION
1. Handle case, when item of RecyclerView is longer than parent: solution is to add a ScrollToElementAction.
2. Support actions on RecyclerView item's child.